### PR TITLE
Generate iCalendar file

### DIFF
--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -28,3 +28,24 @@ def save_data(var_name, obj):
     target = os.path.join(DATA_DIR, var_name + '.js')
     with open(target, 'w') as file:
         file.write(f'{var_name} = {json.dumps(obj, indent=2)};\n')
+    save_ical(obj)
+
+def save_ical(var_name, obj):
+    target = os.path.join(DATA_DIR, var_name + '.ics')
+    with open(target, 'w') as file:
+        # print icalendar header info
+        file.write('BEGIN:VCALENDAR\n')
+        file.write('VERSION:2.0\n')
+        file.write('PRODID:-//Gradescope//NONSGML Assignments//EN\n')
+
+        # loop through assignments in each class
+        for course in list.values():
+            for assignment in course:
+                # create event entry
+                file.write('BEGIN:VEVENT\n')
+                file.write('SUMMARY:' + assignment['title'] + '\n')
+                file.write('DTSTART:' + assignment['dueDate'].replace('-','').replace(':','') + '\n')
+                file.write('LOCATION:' + assignment['course'] + '\n')
+                file.write('URL:' + assignment['link'] + '\n')
+                file.write('END:VEVENT\n')
+        file.write('END:VCALENDAR')

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -28,7 +28,7 @@ def save_data(var_name, obj):
     target = os.path.join(DATA_DIR, var_name + '.js')
     with open(target, 'w') as file:
         file.write(f'{var_name} = {json.dumps(obj, indent=2)};\n')
-    save_ical(obj)
+    save_ical(var_name, obj)
 
 def save_ical(var_name, obj):
     target = os.path.join(DATA_DIR, var_name + '.ics')

--- a/src/common/utils.py
+++ b/src/common/utils.py
@@ -39,7 +39,7 @@ def save_ical(var_name, obj):
         file.write('PRODID:-//Gradescope//NONSGML Assignments//EN\n')
 
         # loop through assignments in each class
-        for course in list.values():
+        for course in obj.values():
             for assignment in course:
                 # create event entry
                 file.write('BEGIN:VEVENT\n')


### PR DESCRIPTION
Generates an iCalendar file so your Apple/Google calendar can automatically pull assignments from Planit. The .ics file's URL can be added as a calendar subscription. (for example, mine is https://raw.githubusercontent.com/zyonse/planit/main/data/assignments.ics)